### PR TITLE
PluginUI.cs: optionally hide targets without a description.

### DIFF
--- a/AntPanel/Settings.cs
+++ b/AntPanel/Settings.cs
@@ -13,5 +13,9 @@ namespace AntPanel
         [DefaultValue("")]
         [Editor(typeof(FolderNameEditor), typeof(UITypeEditor))]
         public string AntPath { get; set; }
+
+        [DisplayName("Hide no-description targets"), DefaultValue(false)]
+        [Description("Hide targets that don't have a description (unless all of the targets don't have one)")]
+        public Boolean SkipHiddenTargets { get; set; }
     }
 }


### PR DESCRIPTION
Closes #26 

Settings.cs: added the SkipHiddenTargets option to control this behavior.
Note: with this option turned on, the panel shows the same target as listed by running `ant -projecthelp`.