### PR TITLE
Setting for additional arguments, and a popup for user input support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 obj/
+AntInputHandler/ant.jar

--- a/AntInputHandler/build.bat
+++ b/AntInputHandler/build.bat
@@ -1,0 +1,13 @@
+@echo off
+if exist ant.jar (
+	dir /s /B *.java > sources.txt
+	if not exist bin mkdir bin
+	javac -classpath ant.jar -d bin @sources.txt
+	del sources.txt
+	cd bin
+	jar -cf ant-input.jar org
+	echo Place the `ant-input.jar` file in the `lib` folder of your `ant` directory.
+) else (
+	echo Could not find `ant.jar`. Please copy it from the `lib` folder of your `ant` directory.
+)
+pause

--- a/AntInputHandler/org/fdorg/ant/input/AntGuiInputHandler.java
+++ b/AntInputHandler/org/fdorg/ant/input/AntGuiInputHandler.java
@@ -1,0 +1,36 @@
+package org.fdorg.ant.input;
+
+import java.util.Vector;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.input.InputHandler;
+import org.apache.tools.ant.input.InputRequest;
+import org.apache.tools.ant.input.MultipleChoiceInputRequest;
+
+/**
+ * @author Patrick Zahra
+ */
+public class AntGuiInputHandler implements InputHandler {
+	
+	public void handleInput(InputRequest request) throws BuildException {
+		AntInputDialog dlg = new AntInputDialog(
+			request.getPrompt(),
+			request.getDefaultValue(),
+			request instanceof MultipleChoiceInputRequest
+				? ((MultipleChoiceInputRequest)request).getChoices()
+				: null);
+		request.setInput(dlg.result);
+		System.out.println(dlg.result);
+	}
+	
+	//for testing purposes
+	public static void main(String[] a) {
+		AntGuiInputHandler agih = new AntGuiInputHandler();
+		Vector<String> items = new Vector<String>();
+		items.add("one");
+		items.add("two");
+		items.add("three");
+		MultipleChoiceInputRequest req = new MultipleChoiceInputRequest("prompt\nhere", items);
+		req.setDefaultValue("one");
+		agih.handleInput(req);
+	}
+}

--- a/AntInputHandler/org/fdorg/ant/input/AntInputDialog.java
+++ b/AntInputHandler/org/fdorg/ant/input/AntInputDialog.java
@@ -1,0 +1,81 @@
+package org.fdorg.ant.input;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.Vector;
+import javax.swing.*;
+
+/**
+ * @author Patrick Zahra
+ */
+public class AntInputDialog extends JDialog implements ActionListener {
+	private JButton btnOk, btnCancel;
+	private JTextField txtInput;
+	private JComboBox<String> lstInput;
+	private JLabel lblInput;
+	public String result;
+	
+	public AntInputDialog(String label, String def, Vector<String> choices) {
+		super((JFrame)null, "Ant Input", true);
+		
+		JPanel panel = new JPanel();
+		Boolean wait = false;
+		if (label == "") {
+			label = "Press Return key to continue...";
+			wait = true;
+		}
+		lblInput = new JLabel(label);
+		panel.add(lblInput);
+		getContentPane().add(panel, BorderLayout.NORTH);
+
+		panel = new JPanel();
+		txtInput = new JTextField(def, 20);
+		if (choices != null) {
+			if (choices.size() == 0 || choices.get(0) == "") {
+				wait = true;
+			} else {
+				lstInput = new JComboBox<String>(choices);
+				if (def != "") lstInput.setSelectedItem(def);
+				lstInput.addActionListener(this);
+				panel.add(lstInput);
+			}
+		} else if (!wait) {
+			panel.add(txtInput);
+		}
+		getContentPane().add(panel);
+		
+		panel = new JPanel();
+		btnCancel = new JButton("Cancel"); 
+		if (!wait) {
+			panel.add(btnCancel); 
+			btnCancel.addActionListener(this);
+		}
+		btnOk = new JButton("OK"); 
+		panel.add(btnOk); 
+		btnOk.addActionListener(this); 
+		getContentPane().add(panel, BorderLayout.SOUTH);
+		
+		getRootPane().setDefaultButton(btnOk);
+		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+		pack(); 
+		setVisible(true);
+	}
+	
+	public void actionPerformed(ActionEvent e) {
+		if (e.getSource() == lstInput) {
+			txtInput.setText((String)lstInput.getSelectedItem());
+		}
+		if (e.getSource() == btnOk) {
+			result = txtInput.getText();
+			setVisible(false); 
+			dispose(); 
+		}
+		if (e.getSource() == btnCancel) {
+			setVisible(false); 
+			dispose(); 
+		}
+	}
+}

--- a/AntPanel/PluginMain.cs
+++ b/AntPanel/PluginMain.cs
@@ -137,11 +137,13 @@ namespace AntPanel
 	    public void RunTarget(string file, string target)
         {
 	        var antPath = ((Settings)Settings).AntPath;
+			var addArgs = ((Settings)Settings).AdditionalArgs;
             var command = /*PluginBase.MainForm.CommandPromptExecutable ??*/ Path.Combine(Environment.SystemDirectory, "cmd.exe");
             var arguments = "/c ";
             if (string.IsNullOrEmpty(antPath)) arguments += "ant";
             else arguments += Path.Combine(Path.Combine(antPath, "bin"), "ant");
-            arguments += $" -buildfile \"{file}\" \"{target}\"";
+			if (!string.IsNullOrEmpty(addArgs)) arguments += " " + addArgs;
+			arguments += $" -buildfile \"{file}\" \"{target}\"";
             PluginBase.MainForm.CallCommand("RunProcessCaptured", $"{command};{arguments}");
         }
 

--- a/AntPanel/Settings.cs
+++ b/AntPanel/Settings.cs
@@ -17,5 +17,10 @@ namespace AntPanel
         [DisplayName("Hide no-description targets"), DefaultValue(false)]
         [Description("Hide targets that don't have a description (unless all of the targets don't have one)")]
         public Boolean SkipHiddenTargets { get; set; }
-    }
+
+		[DisplayName("Additional Arguments")]
+		[Description("More parameters to add to the Ant call (e.g. -inputhandler org.fdorg.ant.input.AntGuiInputHandler)")]
+		[DefaultValue("")]
+		public String AdditionalArgs { get; set; }
+	}
 }


### PR DESCRIPTION
Compile the ant input handler with the batch file, and place it in the `ant\lib` folder. You can now use the new Additional Arguments setting to tell ant how to use the `<input>` task.